### PR TITLE
Set PREFERRED_PARSER

### DIFF
--- a/plugin-dir/check_rhv.pl
+++ b/plugin-dir/check_rhv.pl
@@ -37,6 +37,8 @@ use HTTP::Request::Common qw(POST);
 use HTTP::Headers;
 use Getopt::Long;
 use XML::Simple;
+$XML::Simple::PREFERRED_PARSER = 'XML::Parser';
+
 use DateTime;
 use DateTime::Format::DateParse ;
 


### PR DESCRIPTION
Prevent `could not find ParserDetails.ini in /usr/lib64/perl5/XML/SAX`

See https://stackoverflow.com/questions/22023894/could-not-find-parserdetails-ini

This is not blocking, but it prevent the warning in the output