### PR TITLE
Update for fedora 35 rhel8

### DIFF
--- a/README
+++ b/README
@@ -30,6 +30,17 @@ Installation
 The check_rhv installation can be used by following the standard autotools
 installation process, documented in the INSTALL file. As a quick start you can do
 
+
+NOTE: Deploy the dependencies below for the system version you have here, first
+For RHEL 7/8 or Fedora 35 run in this order (cwd is the check_rhv repo path)
+$ /usr/bin/aclocal
+$ automake --add-missing
+$ autoconf
+$ ./configure
+$ make all
+$ sudo make install
+
+For other systems, use the standard method of deploying
 $ ./configure
 $ make all
 # make install
@@ -54,10 +65,14 @@ as an RPM package.
 Also make sure that the following requirements are met:
 Perl
 Perl-Modules:
-  LWP::UserAgent
-  perl-Crypt-SSLeay
-  HTTP::Request
+  Crypt::SSLeay
+  DateTime
+  DateTime::Format::DateParse
   Getopt::Long
+  HTTP::Request
+  LWP
+  LWP::Protocol:https
+  LWP::UserAgent
   XML:Simple
 
 For Fedora 19 (and newer) install the following packages:
@@ -67,9 +82,14 @@ For Fedora 19 (and newer) install the following packages:
 For RHEL 6 install the following packages:
 # yum install perl-Crypt-SSLeay perl-libwww-perl perl-XML-Simple
 
+For RHEL 7 install the following packages:
+$ sudo yum install perl-LWP-Protocol-https openssl perl-DateTime-Format-DateParse.noarch perl-DateTime autoconf-archive.noarch automake libtool perl-libwww-perl autoconf perl-XML-Simple.noarch 
+
 For Debian Squeeze install the following packages:
 # apt-get install libwww-perl libcrypt-ssleay-perl libxml-simple-perl
 
+For Fedora 35 or RHEL 8, install the following packages:
+$ sudo dnf install perl-LWP-Protocol-https openssl perl-DateTime-Format-DateParse.noarch perl-DateTime autoconf-archive.noarch automake libtool perl-libwww-perl autoconf perl-XML-Simple.noarch
 
 Documentation
 =============

--- a/README
+++ b/README
@@ -59,6 +59,25 @@ To change the user and group ownership of these files use:
 --with-nagios-user=<user>
 --with-nagios-group=<group>
 
+For example if you use Icinga and do not use PNP, you can use the following commands to configure your install for that:
+$ ./configure --with-nagios-user=icinga --with-nagios-group=icinga --disable-pnp-template --prefix=/usr/lib64/nagios/plugins/
+
+
+  General Options:
+  ------------------------- -------------------------
+               Nagios user: icinga
+              Nagios group: icinga
+         Plugins directory: /usr/lib64/nagios/plugins
+             PNP directory: /usr/local/pnp4nagios/share
+      Install PNP template: no
+
+
+Review the options above for accuray. If they look okay,
+type 'make all' to compile.
+
+[icinga@vaulttest check_rhv]$ 
+
+
 The 'nagios-plugins-rhv.spec' file demonstrates how to distribute check_rhv
 as an RPM package.
 

--- a/configure.ac
+++ b/configure.ac
@@ -32,12 +32,12 @@ AC_CANONICAL_HOST
 
 # Check for programs
 AC_PATH_PROG([PERL],[perl])
-AC_PROG_PERL_MODULES( LWP::UserAgent, , AC_MSG_ERROR(Missing Perl module LWP::UserAgent))
-AC_PROG_PERL_MODULES( HTTP::Request, , AC_MSG_ERROR(Missing Perl module HTTP::Request))
-AC_PROG_PERL_MODULES( HTTP::Request::Common, , AC_MSG_ERROR(Missing Perl module HTTP::Request::Common))
-AC_PROG_PERL_MODULES( Getopt::Long, , AC_MSG_ERROR(Missing Perl module Getopt::Long))
-AC_PROG_PERL_MODULES( XML::Simple, , AC_MSG_ERROR(Missing Perl module XML::Simple))
-AC_PROG_PERL_MODULES( Data::Dumper, , AC_MSG_ERROR(Missing Perl module Data::Dumper))
+AX_PROG_PERL_MODULES( LWP::UserAgent, , AC_MSG_ERROR(Missing Perl module LWP::UserAgent))
+AX_PROG_PERL_MODULES( HTTP::Request, , AC_MSG_ERROR(Missing Perl module HTTP::Request))
+AX_PROG_PERL_MODULES( HTTP::Request::Common, , AC_MSG_ERROR(Missing Perl module HTTP::Request::Common))
+AX_PROG_PERL_MODULES( Getopt::Long, , AC_MSG_ERROR(Missing Perl module Getopt::Long))
+AX_PROG_PERL_MODULES( XML::Simple, , AC_MSG_ERROR(Missing Perl module XML::Simple))
+AX_PROG_PERL_MODULES( Data::Dumper, , AC_MSG_ERROR(Missing Perl module Data::Dumper))
 
 # Options
 AC_ARG_WITH(nagios_user,AC_HELP_STRING([--with-nagios-user=<user>],[sets user name to run Nagios]),nagios_user=$withval,nagios_user=nagios)


### PR DESCRIPTION
I've added some updates instructions for the README, as well as fixing the m4 directives in the configure.ac (moved from configure.in), specifically `AC_PROG_PERL_MODULES` has been replaced by `AX_PROG_PERL_MODULES`

I've tested this on RHEL 7, RHEL 8, and Fedora 35, and included the relevant instructions and fixes in this commit.